### PR TITLE
Ensure that mem*() family function implementations are not shadowed by macros

### DIFF
--- a/src/libc.c
+++ b/src/libc.c
@@ -2,6 +2,9 @@
 #include <stddef.h>
 #include <libc.h>
 
+#ifdef memcpy
+#  undef memcpy
+#endif
 void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
     uint8_t *restrict pdest = (uint8_t *restrict)dest;
     const uint8_t *restrict psrc = (const uint8_t *restrict)src;
@@ -13,6 +16,9 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
     return dest;
 }
 
+#ifdef memset
+#  undef memset
+#endif
 void *memset(void *s, int c, size_t n) {
     uint8_t *p = (uint8_t *)s;
 
@@ -23,6 +29,9 @@ void *memset(void *s, int c, size_t n) {
     return s;
 }
 
+#ifdef memmove
+#  undef memmove
+#endif
 void *memmove(void *dest, const void *src, size_t n) {
     uint8_t *pdest = (uint8_t *)dest;
     const uint8_t *psrc = (const uint8_t *)src;
@@ -40,6 +49,9 @@ void *memmove(void *dest, const void *src, size_t n) {
     return dest;
 }
 
+#ifdef memcmp
+#  undef memcmp
+#endif
 int memcmp(const void *s1, const void *s2, size_t n) {
     const uint8_t *p1 = (const uint8_t *)s1;
     const uint8_t *p2 = (const uint8_t *)s2;

--- a/src/libc.h
+++ b/src/libc.h
@@ -9,8 +9,9 @@ void *memmove(void *dest, const void *src, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
 
 /* Access builtin version by default. */
-#define memcpy(d,s,l) __builtin_memcpy(d,s,l)
-#define memset(d,c,l) __builtin_memset(d,c,l)
-#define memcmp	__builtin_memcmp
+#define memcpy __builtin_memcpy
+#define memset __builtin_memset
+#define memmove __builtin_memmove
+#define memcmp __builtin_memcmp
 
 #endif


### PR DESCRIPTION
This also unbreaks the Clang build.
