### PR TITLE
The first arg to GetPciLegacyRom() is 0xMMmm, not version

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -371,7 +371,7 @@ EFI_STATUS csmwrap_video_oprom_init(struct csmwrap_priv *priv)
             );
 
     Status = GetPciLegacyRom (
-             3, // ???
+             0x0300, // ???
              PciConfigHeader.Hdr.VendorId,
              PciConfigHeader.Hdr.DeviceId,
              &LocalRomImage,


### PR DESCRIPTION
Where M=Major and m=minor.
